### PR TITLE
[unpack] Golang pure unpack

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/ulikunitz/xz v0.5.10 // indirect
 	golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f // indirect
 	golang.org/x/sys v0.0.0-20220429121018-84afa8d3f7b3 // indirect
 	golang.org/x/term v0.0.0-20220411215600-e5f449aeb171 // indirect

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
+github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f h1:OeJjE6G4dgCY4PIXvIRQbE8+RX+uXZyGhUy/ksMGJoc=
 golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=

--- a/unpack/unpack.go
+++ b/unpack/unpack.go
@@ -19,7 +19,7 @@ type UnpackFn func(src string, dir string) error
 
 var unpackMap = map[unpackExt]UnpackFn{
 	extTarGz: Untargz,
-	extTarXz: UntarxzExec,
+	extTarXz: Untarxz,
 	extZip:   Unzip,
 }
 

--- a/unpack/unpack.go
+++ b/unpack/unpack.go
@@ -1,27 +1,30 @@
 package unpack
 
 import (
-	"archive/zip"
 	"fmt"
-	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
-	"strings"
 	"webman/utils"
+)
+
+type unpackExt string
+
+const (
+	extTarGz unpackExt = "tar.gz"
+	extTarXz unpackExt = "tar.xz"
+	extZip   unpackExt = "zip"
 )
 
 type UnpackFn func(src string, dir string) error
 
-var unpackMap = map[string]UnpackFn{
-	"tar.gz": untarExec,
-	"tar.xz": untarExec,
-	"zip":    Unzip,
+var unpackMap = map[unpackExt]UnpackFn{
+	extTarGz: Untargz,
+	extTarXz: UntarxzExec,
+	extZip:   Unzip,
 }
 
 func Unpack(src string, pkg string, stem string, ext string, hasRoot bool) error {
-	unpackFn, exists := unpackMap[ext]
+	unpackFn, exists := unpackMap[unpackExt(ext)]
 	if !exists {
 		return fmt.Errorf("no unpack function for extension: %q", ext)
 	}
@@ -58,60 +61,6 @@ func Unpack(src string, pkg string, stem string, ext string, hasRoot bool) error
 		if err = unpackFn(src, pkgDest); err != nil {
 			return fmt.Errorf("failed to extract file: %v", err)
 		}
-	}
-	return nil
-}
-
-func untarExec(src string, dir string) error {
-	if runtime.GOOS == "windows" {
-		return fmt.Errorf("windows doesn't have support for tarballs")
-	}
-	cmd := exec.Command("tar", "-xf", src, "--directory="+dir)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
-}
-
-func Unzip(src string, dir string) error {
-	archive, err := zip.OpenReader(src)
-	if err != nil {
-		return fmt.Errorf("unable to unzip: %v", err)
-	}
-	defer archive.Close()
-
-	for _, f := range archive.File {
-		fileName := f.Name
-
-		filePath := filepath.Join(dir, fileName)
-
-		if !strings.HasPrefix(filePath, filepath.Clean(dir)+string(os.PathSeparator)) {
-			return fmt.Errorf("invalid file path")
-		}
-		if f.FileInfo().IsDir() {
-			os.MkdirAll(filePath, os.ModePerm)
-			continue
-		}
-
-		if err := os.MkdirAll(filepath.Dir(filePath), os.ModePerm); err != nil {
-			return err
-		}
-
-		dstFile, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
-		if err != nil {
-			return err
-		}
-
-		fileInArchive, err := f.Open()
-		if err != nil {
-			return err
-		}
-
-		if _, err := io.Copy(dstFile, fileInArchive); err != nil {
-			return err
-		}
-
-		dstFile.Close()
-		fileInArchive.Close()
 	}
 	return nil
 }

--- a/unpack/unpack_targz.go
+++ b/unpack/unpack_targz.go
@@ -1,0 +1,71 @@
+package unpack
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func Untargz(src string, dir string) error {
+	// Open compress file
+	file, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	// Add gzip support
+	uncompressedStream, err := gzip.NewReader(file)
+	if err != nil {
+		return err
+	}
+	defer uncompressedStream.Close()
+
+	// Read content file
+	archive := tar.NewReader(uncompressedStream)
+
+	var infinityLoop = true
+	for infinityLoop {
+		header, err := archive.Next()
+
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			return err
+		}
+
+		fileName := header.Name
+
+		filePath := filepath.Join(dir, fileName)
+
+		if !strings.HasPrefix(filePath, filepath.Clean(dir)+string(os.PathSeparator)) {
+			return fmt.Errorf("invalid file path")
+		}
+		if header.FileInfo().IsDir() {
+			os.MkdirAll(filePath, os.ModePerm)
+			continue
+		}
+
+		if err := os.MkdirAll(filepath.Dir(filePath), os.ModePerm); err != nil {
+			return err
+		}
+
+		dstFile, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, header.FileInfo().Mode())
+		if err != nil {
+			return err
+		}
+
+		if _, err := io.Copy(dstFile, archive); err != nil {
+			return err
+		}
+
+		dstFile.Close()
+	}
+	return nil
+}

--- a/unpack/unpack_tarxz.go
+++ b/unpack/unpack_tarxz.go
@@ -1,0 +1,18 @@
+package unpack
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+)
+
+func UntarxzExec(src string, dir string) error {
+	if runtime.GOOS == "windows" {
+		return fmt.Errorf("windows doesn't have support for tarballs")
+	}
+	cmd := exec.Command("tar", "-xf", src, "--directory="+dir)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/unpack/unpack_tarxz.go
+++ b/unpack/unpack_tarxz.go
@@ -1,18 +1,71 @@
 package unpack
 
 import (
+	"archive/tar"
 	"fmt"
+	"io"
 	"os"
-	"os/exec"
-	"runtime"
+	"path/filepath"
+	"strings"
+
+	"github.com/ulikunitz/xz"
 )
 
-func UntarxzExec(src string, dir string) error {
-	if runtime.GOOS == "windows" {
-		return fmt.Errorf("windows doesn't have support for tarballs")
+func Untarxz(src string, dir string) error {
+	// Open compress file
+	file, err := os.Open(src)
+	if err != nil {
+		return err
 	}
-	cmd := exec.Command("tar", "-xf", src, "--directory="+dir)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	defer file.Close()
+
+	// Add xz support
+	uncompressedStream, err := xz.NewReader(file)
+	if err != nil {
+		return err
+	}
+
+	// Read content file
+	archive := tar.NewReader(uncompressedStream)
+
+	var infinityLoop = true
+	for infinityLoop {
+		header, err := archive.Next()
+
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			return err
+		}
+
+		fileName := header.Name
+
+		filePath := filepath.Join(dir, fileName)
+
+		if !strings.HasPrefix(filePath, filepath.Clean(dir)+string(os.PathSeparator)) {
+			return fmt.Errorf("invalid file path")
+		}
+		if header.FileInfo().IsDir() {
+			os.MkdirAll(filePath, os.ModePerm)
+			continue
+		}
+
+		if err := os.MkdirAll(filepath.Dir(filePath), os.ModePerm); err != nil {
+			return err
+		}
+
+		dstFile, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, header.FileInfo().Mode())
+		if err != nil {
+			return err
+		}
+
+		if _, err := io.Copy(dstFile, archive); err != nil {
+			return err
+		}
+
+		dstFile.Close()
+	}
+	return nil
 }

--- a/unpack/unpack_zip.go
+++ b/unpack/unpack_zip.go
@@ -1,0 +1,54 @@
+package unpack
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func Unzip(src string, dir string) error {
+	archive, err := zip.OpenReader(src)
+	if err != nil {
+		return fmt.Errorf("unable to unzip: %v", err)
+	}
+	defer archive.Close()
+
+	for _, f := range archive.File {
+		fileName := f.Name
+
+		filePath := filepath.Join(dir, fileName)
+
+		if !strings.HasPrefix(filePath, filepath.Clean(dir)+string(os.PathSeparator)) {
+			return fmt.Errorf("invalid file path")
+		}
+		if f.FileInfo().IsDir() {
+			os.MkdirAll(filePath, os.ModePerm)
+			continue
+		}
+
+		if err := os.MkdirAll(filepath.Dir(filePath), os.ModePerm); err != nil {
+			return err
+		}
+
+		dstFile, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+		if err != nil {
+			return err
+		}
+
+		fileInArchive, err := f.Open()
+		if err != nil {
+			return err
+		}
+
+		if _, err := io.Copy(dstFile, fileInArchive); err != nil {
+			return err
+		}
+
+		dstFile.Close()
+		fileInArchive.Close()
+	}
+	return nil
+}


### PR DESCRIPTION
Added support for decompressing tar.xz and tar.gz files, without exec(tar)
Allows to unzip .tar files in windows

**Details**
* To decompress tar.gz the standard library is used
* To decompress tar.xz files, github.com/ulikunitz/xz was used, which is a 100% go library, it should work on a windows installation

**test**
* Linux (tar.gz, tar.xz)
* Windows (tar.gz)

Curlie works on windows, although the recipe needs to be modified, please add a related [pull request](https://github.com/candrewlee14/webman-pkgs/pull/3)