### PR TITLE
Add JSON schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Webman does version management.
 
 ## Check Packages & Test Locally
 
-You can create new package recipes by adding a simple `[PKG_NAME].yaml` file in a cloned [webman-pkgs](https://github.com/candrewlee14/webman-pkgs) directory. Check if it is in a valid format with `webman check [WEBMAN-PKGS-DIR]`.
+You can create new package recipes by adding a simple recipe file in a cloned [webman-pkgs](https://github.com/candrewlee14/webman-pkgs) directory. Check if it is in a valid format with `webman check [WEBMAN-PKGS-DIR]`.
 
 Next, you can test installing your local recipes with the `--local-recipes` flag on the `add` command, like `webman add [PKG_NAME] -l [WEBMAN-PKGS-DIR]`.
 
@@ -96,9 +96,7 @@ Run the script above or download the binary for your OS and architecture [here](
 Alternatively, if you have Go installed, run:
 
 ```bash
-git clone https://github.com/candrewlee14/webman.git
-cd webman
-go install .
+go install https://github.com/candrewlee14/webman@latest
 ```
 
 Next, add `~/.webman/bin` to your system PATH.

--- a/cmd/dev/check/check.go
+++ b/cmd/dev/check/check.go
@@ -70,7 +70,7 @@ The "check" subcommand checks that all recipes in a directory are valid.`,
 }
 
 func CheckPkgConfig(pkg string) error {
-	pkgConfPath := filepath.Join(utils.WebmanRecipeDir, "pkgs", pkg+".yaml")
+	pkgConfPath := filepath.Join(utils.WebmanRecipeDir, "pkgs", pkg+utils.PkgRecipeExt)
 	fi, err := os.Open(pkgConfPath)
 	if err != nil {
 		return err

--- a/cmd/dev/check/check.go
+++ b/cmd/dev/check/check.go
@@ -43,7 +43,7 @@ The "check" subcommand checks that all recipes in a directory are valid.`,
 
 				go func() {
 					recipeName := recipe.Name()
-					pkg := strings.ReplaceAll(recipeName, ".yaml", "")
+					pkg := strings.ReplaceAll(recipeName, utils.PkgRecipeExt, "")
 					err := CheckPkgConfig(pkg)
 					if err != nil {
 						var lintErr schema.ResultErrors

--- a/cmd/dev/check/check.go
+++ b/cmd/dev/check/check.go
@@ -1,13 +1,13 @@
 package check
 
 import (
-	"fmt"
+	"errors"
+	"github.com/candrewlee14/webman/schema"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 
-	"github.com/candrewlee14/webman/pkgparse"
 	"github.com/candrewlee14/webman/utils"
 
 	"github.com/fatih/color"
@@ -46,7 +46,14 @@ The "check" subcommand checks that all recipes in a directory are valid.`,
 					pkg := strings.ReplaceAll(recipeName, ".yaml", "")
 					err := CheckPkgConfig(pkg)
 					if err != nil {
-						color.Red("%s: %s", color.YellowString(recipeName), color.RedString("%v", err))
+						var lintErr schema.ResultErrors
+						if errors.As(err, &lintErr) {
+							for _, le := range lintErr {
+								color.Red("%s: %s", color.YellowString(recipeName), color.RedString("%s: %s", le.Field(), le.Description()))
+							}
+						} else {
+							color.Red("%s: %s", color.YellowString(recipeName), color.RedString("%v", err))
+						}
 						success = false
 					}
 					wg.Done()
@@ -63,45 +70,13 @@ The "check" subcommand checks that all recipes in a directory are valid.`,
 }
 
 func CheckPkgConfig(pkg string) error {
-	pkgConf, err := pkgparse.ParsePkgConfigLocal(pkg, true)
+	pkgConfPath := filepath.Join(utils.WebmanRecipeDir, "pkgs", pkg+".yaml")
+	fi, err := os.Open(pkgConfPath)
 	if err != nil {
 		return err
 	}
-	if len(pkgConf.Title) == 0 {
-		return fmt.Errorf("title field empty")
-	}
-	if len(pkgConf.Tagline) == 0 {
-		return fmt.Errorf("tagline field empty")
-	}
-	if len(pkgConf.About) == 0 {
-		return fmt.Errorf("about field empty")
-	}
-
-	if len(pkgConf.FilenameFormat) == 0 {
-		return fmt.Errorf("filename_format field empty")
-	}
-	if len(pkgConf.BaseDownloadUrl) == 0 {
-		return fmt.Errorf("base_download_url field empty")
-	}
-	if len(pkgConf.LatestStrategy) == 0 {
-		return fmt.Errorf("latest_strategy field empty")
-	}
-	switch pkgConf.LatestStrategy {
-	case "github-release":
-		if len(pkgConf.GitUser) == 0 {
-			return fmt.Errorf("missing git_user because github-release latest strategy")
-		}
-		if len(pkgConf.GitRepo) == 0 {
-			return fmt.Errorf("missing git_repo because github-release latest strategy")
-		}
-	case "arch-linux-community":
-		if len(pkgConf.ArchLinuxPkgName) == 0 {
-			return fmt.Errorf("missing arch_linux_pkg_name because arch-linux-community latest strategy")
-		}
-	default:
-		return fmt.Errorf("invalid latest strategy")
-	}
-	return nil
+	defer fi.Close()
+	return schema.Lint(fi)
 }
 
 func init() {

--- a/cmd/dev/dev.go
+++ b/cmd/dev/dev.go
@@ -26,8 +26,6 @@ func init() {
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 
-	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.webman.yaml)")
-
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 

--- a/cmd/group/add/group_add.go
+++ b/cmd/group/add/group_add.go
@@ -92,8 +92,6 @@ func init() {
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 
-	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.webman.yaml)")
-
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 	AddCmd.Flags().BoolVar(&doRefresh, "refresh", false, "force refresh of package recipes")

--- a/cmd/group/group.go
+++ b/cmd/group/group.go
@@ -29,8 +29,6 @@ func init() {
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 
-	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.webman.yaml)")
-
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 

--- a/cmd/group/remove/group_remove.go
+++ b/cmd/group/remove/group_remove.go
@@ -77,8 +77,6 @@ func init() {
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 
-	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.webman.yaml)")
-
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 

--- a/cmd/search/search.go
+++ b/cmd/search/search.go
@@ -38,7 +38,7 @@ The "search" subcommand starts an interactive window to find and display info ab
 		}
 		pkgInfos := make([]*pkgparse.PkgInfo, len(files))
 		for i, file := range files {
-			pkg := strings.Split(file.Name(), ".yaml")[0]
+			pkg := strings.Split(file.Name(), utils.PkgRecipeExt)[0]
 			pkgInfo, err := pkgparse.ParsePkgInfo(pkg)
 			if err != nil {
 				panic(err)

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,9 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f // indirect
 	golang.org/x/sys v0.0.0-20220429121018-84afa8d3f7b3 // indirect
 	golang.org/x/term v0.0.0-20220411215600-e5f449aeb171 // indirect

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,12 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f h1:OeJjE6G4dgCY4PIXvIRQbE8+RX+uXZyGhUy/ksMGJoc=
 golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=

--- a/pkgparse/github.go
+++ b/pkgparse/github.go
@@ -75,7 +75,7 @@ type RefreshFile struct {
 }
 
 func ShouldRefreshRecipes() (bool, error) {
-	refreshFileDir := filepath.Join(utils.WebmanRecipeDir, "refresh.yaml")
+	refreshFileDir := filepath.Join(utils.WebmanRecipeDir, utils.RefreshFileName)
 	data, err := os.ReadFile(refreshFileDir)
 	if err != nil {
 		// if err occured and file does exist
@@ -118,7 +118,6 @@ func RefreshRecipes() error {
 	}
 	tmpZipFile, err := os.CreateTemp(utils.WebmanTmpDir, "recipes-*.zip")
 	if err != nil {
-		fmt.Println("Made refresh.zip file")
 		return err
 	}
 	if _, err = io.Copy(tmpZipFile, r.Body); err != nil {
@@ -139,7 +138,7 @@ func RefreshRecipes() error {
 	if err = os.Rename(innerTmpFolder, utils.WebmanRecipeDir); err != nil {
 		return err
 	}
-	refreshFilePath := filepath.Join(utils.WebmanRecipeDir, "refresh.yaml")
+	refreshFilePath := filepath.Join(utils.WebmanRecipeDir, utils.RefreshFileName)
 	curTime := time.Now()
 	data, err := yaml.Marshal(RefreshFile{&curTime})
 	if err != nil {

--- a/pkgparse/group_parser.go
+++ b/pkgparse/group_parser.go
@@ -20,7 +20,7 @@ type PkgGroupConfig struct {
 }
 
 func ParseGroupConfig(group string) *PkgGroupConfig {
-	groupPath := filepath.Join(utils.WebmanRecipeDir, "groups", group+".yaml")
+	groupPath := filepath.Join(utils.WebmanRecipeDir, "groups", group+utils.GroupRecipeExt)
 	if _, err := os.Stat(groupPath); err != nil {
 		if os.IsNotExist(err) {
 			color.Red("No package group named %s", color.YellowString(group))

--- a/pkgparse/info.go
+++ b/pkgparse/info.go
@@ -19,7 +19,7 @@ type PkgInfo struct {
 }
 
 func ParsePkgInfo(pkg string) (*PkgInfo, error) {
-	pkgConfPath := filepath.Join(utils.WebmanRecipeDir, "pkgs", pkg+".yaml")
+	pkgConfPath := filepath.Join(utils.WebmanRecipeDir, "pkgs", pkg+utils.PkgRecipeExt)
 	dat, err := os.ReadFile(pkgConfPath)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/pkgparse/parser.go
+++ b/pkgparse/parser.go
@@ -102,9 +102,9 @@ func (pkgConf *PkgConfig) GetMyBinPaths() ([]string, error) {
 }
 
 // Check using file.
-// If using.yaml file doesn't exist, it is not using anything
+// If UsingFile doesn't exist, it is not using anything
 func CheckUsing(pkg string) (*string, error) {
-	usingPath := filepath.Join(utils.WebmanPkgDir, pkg, "using.yaml")
+	usingPath := filepath.Join(utils.WebmanPkgDir, pkg, utils.UsingFileName)
 	usingContent, err := os.ReadFile(usingPath)
 	if err != nil {
 		return nil, nil
@@ -124,7 +124,7 @@ func WriteUsing(pkg string, using string) error {
 	if err != nil {
 		return err
 	}
-	usingPath := filepath.Join(utils.WebmanPkgDir, pkg, "using.yaml")
+	usingPath := filepath.Join(utils.WebmanPkgDir, pkg, utils.UsingFileName)
 	if err := os.WriteFile(usingPath, data, os.ModePerm); err != nil {
 		return err
 	}
@@ -132,7 +132,7 @@ func WriteUsing(pkg string, using string) error {
 }
 
 func RemoveUsing(pkg string) error {
-	usingPath := filepath.Join(utils.WebmanPkgDir, pkg, "using.yaml")
+	usingPath := filepath.Join(utils.WebmanPkgDir, pkg, utils.UsingFileName)
 	if err := os.Remove(usingPath); err != nil {
 		return err
 	}
@@ -140,7 +140,7 @@ func RemoveUsing(pkg string) error {
 }
 
 func ParsePkgConfigOnline(pkg string) (*PkgConfig, error) {
-	pkgConfUrl := "https://raw.githubusercontent.com/candrewlee14/webman-pkgs/main/pkgs/" + pkg + ".yaml"
+	pkgConfUrl := "https://raw.githubusercontent.com/candrewlee14/webman-pkgs/main/pkgs/" + pkg + utils.PkgRecipeExt
 	r, err := http.Get(pkgConfUrl)
 	if err != nil {
 		return nil, fmt.Errorf("unable to download %s package recipe: %v", pkg, err)
@@ -167,7 +167,7 @@ func ParsePkgConfigOnline(pkg string) (*PkgConfig, error) {
 }
 
 func ParsePkgConfigLocal(pkg string, strict bool) (*PkgConfig, error) {
-	pkgConfPath := filepath.Join(utils.WebmanRecipeDir, "pkgs", pkg+".yaml")
+	pkgConfPath := filepath.Join(utils.WebmanRecipeDir, "pkgs", pkg+utils.PkgRecipeExt)
 	dat, err := os.ReadFile(pkgConfPath)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/schema/convert.go
+++ b/schema/convert.go
@@ -1,0 +1,46 @@
+package schema
+
+import (
+	"fmt"
+
+	"github.com/go-yaml/yaml"
+)
+
+// Unmarshal YAML to map[string]any instead of map[any]any.
+func Unmarshal(in []byte, out any) error {
+	var res any
+
+	if err := yaml.Unmarshal(in, &res); err != nil {
+		return err
+	}
+	*out.(*any) = mapValue(res)
+
+	return nil
+}
+
+func mapSlice(in []any) []any {
+	res := make([]any, len(in))
+	for i, v := range in {
+		res[i] = mapValue(v)
+	}
+	return res
+}
+
+func mapMap(in map[any]any) map[string]any {
+	res := make(map[string]any)
+	for k, v := range in {
+		res[fmt.Sprintf("%v", k)] = mapValue(v)
+	}
+	return res
+}
+
+func mapValue(v any) any {
+	switch v := v.(type) {
+	case []any:
+		return mapSlice(v)
+	case map[any]any:
+		return mapMap(v)
+	default:
+		return v
+	}
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1,0 +1,49 @@
+package schema
+
+import (
+	_ "embed"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/xeipuuv/gojsonschema"
+)
+
+var (
+	//go:embed schema.json
+	schema       []byte
+	schemaLoader = gojsonschema.NewBytesLoader(schema)
+)
+
+// Lint is for linting a recipe against the schema
+func Lint(r io.Reader) error {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	var m any
+	if err := Unmarshal(data, &m); err != nil {
+		return err
+	}
+	sourceLoader := gojsonschema.NewGoLoader(m)
+	result, err := gojsonschema.Validate(schemaLoader, sourceLoader)
+	if err != nil {
+		return err
+	}
+	if len(result.Errors()) > 0 {
+		return ResultErrors(result.Errors())
+	}
+	return nil
+}
+
+// ResultErrors is a slice of gojsonschema.ResultError that implements error
+type ResultErrors []gojsonschema.ResultError
+
+// Error implements error
+func (r ResultErrors) Error() string {
+	errs := make([]string, 0, len(r))
+	for _, re := range r {
+		errs = append(errs, fmt.Sprintf("%s: %s", re.Field(), re.Description()))
+	}
+	return strings.Join(errs, " | ")
+}

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1,0 +1,253 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/candrewlee14/webman/main/schema/schema.json",
+  "title": "Webman recipe",
+  "description": "A recipe for webman",
+  "type": "object",
+  "required": [
+    "title",
+    "tagline",
+    "about",
+    "filename_format",
+    "base_download_url",
+    "latest_strategy"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "title": {
+      "description": "Recipe title",
+      "type": "string"
+    },
+    "tagline": {
+      "description": "Recipe tagline",
+      "type": "string"
+    },
+    "about": {
+      "description": "Recipe description",
+      "type": "string"
+    },
+    "info_url": {
+      "description": "URL for information/documentation",
+      "type": "string"
+    },
+    "releases_url": {
+      "description": "URL for releases",
+      "type": "string"
+    },
+    "base_download_url": {
+      "description": "Base URL for downloading",
+      "type": "string"
+    },
+    "git_user": {
+      "description": "Git username",
+      "type": "string"
+    },
+    "git_repo": {
+      "description": "Git repository",
+      "type": "string"
+    },
+    "source_url": {
+      "description": "Source URL",
+      "type": "string"
+    },
+    "filename_format": {
+      "description": "Filename format",
+      "type": "string"
+    },
+    "version_format": {
+      "description": "Version format",
+      "type": "string"
+    },
+    "latest_strategy": {
+      "description": "Strategy for resolving latest release",
+      "type": "string",
+      "enum": [
+        "github-release",
+        "arch-linux-community"
+      ]
+    },
+    "force_latest": {
+      "description": "Force latest release",
+      "type": "boolean"
+    },
+    "allow_prerelease": {
+      "description": "Allow pre-releases",
+      "type": "boolean"
+    },
+    "arch_linux_pkg_name": {
+      "description": "Arch Linux package name",
+      "type": "string"
+    },
+    "is_binary": {
+      "description": "Download is a binary",
+      "type": "boolean"
+    },
+    "extract_has_root": {
+      "description": "Extraction has root directory",
+      "type": "boolean"
+    },
+    "os_map": {
+      "description": "OS mappings",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "win": {
+          "$ref": "#/$defs/os_mapping"
+        },
+        "macos": {
+          "$ref": "#/$defs/os_mapping"
+        },
+        "linux": {
+          "$ref": "#/$defs/os_mapping"
+        }
+      }
+    },
+    "arch_map": {
+      "description": "Architecture mappings",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ppc64": {
+          "type": "string"
+        },
+        "368": {
+          "type": "string"
+        },
+        "amd64": {
+          "type": "string"
+        },
+        "arm": {
+          "type": "string"
+        },
+        "arm64": {
+          "type": "string"
+        },
+        "wasm": {
+          "type": "string"
+        },
+        "mips": {
+          "type": "string"
+        },
+        "mips64": {
+          "type": "string"
+        },
+        "mips64le": {
+          "type": "string"
+        },
+        "mipsle": {
+          "type": "string"
+        },
+        "ppc64le": {
+          "type": "string"
+        },
+        "riscv64": {
+          "type": "string"
+        },
+        "s390x": {
+          "type": "string"
+        }
+      }
+    },
+    "ignore": {
+      "description": "Ignore mappings",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "os",
+          "arch"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "os": {
+            "$ref": "#/$defs/os"
+          },
+          "arch": {
+            "$ref": "#/$defs/arch"
+          }
+        }
+      }
+    }
+  },
+  "anyOf": [
+    {
+      "properties": {
+        "latest_strategy": {
+          "const": "github-release"
+        }
+      },
+      "required": [
+        "git_user",
+        "git_repo"
+      ]
+    },
+    {
+      "properties": {
+        "latest_strategy": {
+          "const": "arch-linux-community"
+        }
+      },
+      "required": [
+        "arch_linux_pkg_name"
+      ]
+    }
+  ],
+  "$defs": {
+    "os": {
+      "$comment": "go tool dist list",
+      "description": "Operating system",
+      "type": "string",
+      "enum": [
+        "win",
+        "macos",
+        "linux"
+      ]
+    },
+    "arch": {
+      "$comment": "go tool dist list",
+      "description": "Architecture",
+      "type": "string",
+      "enum": [
+        "ppc64",
+        "368",
+        "amd64",
+        "arm",
+        "arm64",
+        "wasm",
+        "mips",
+        "mips64",
+        "mips64le",
+        "mipsle",
+        "ppc64le",
+        "riscv64",
+        "s390x"
+      ]
+    },
+    "os_mapping": {
+      "description": "OS mapping",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "ext": {
+          "type": "string"
+        },
+        "bin_path": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/candrewlee14/webman/main/schema/schema.json",
-  "title": "Webman recipe",
-  "description": "A recipe for webman",
+  "title": "Webman package recipe",
+  "description": "A package recipe for webman",
   "type": "object",
   "required": [
     "title",
@@ -10,20 +10,18 @@
     "about",
     "filename_format",
     "base_download_url",
-    "latest_strategy"
+    "latest_strategy",
+    "os_map",
+    "arch_map"
   ],
   "additionalProperties": false,
   "properties": {
-    "title": {
-      "description": "Recipe title",
-      "type": "string"
-    },
     "tagline": {
-      "description": "Recipe tagline",
+      "description": "Package tagline",
       "type": "string"
     },
     "about": {
-      "description": "Recipe description",
+      "description": "Package description",
       "type": "string"
     },
     "info_url": {

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -5,7 +5,6 @@
   "description": "A package recipe for webman",
   "type": "object",
   "required": [
-    "title",
     "tagline",
     "about",
     "filename_format",
@@ -108,7 +107,7 @@
         "ppc64": {
           "type": "string"
         },
-        "368": {
+        "386": {
           "type": "string"
         },
         "amd64": {
@@ -207,7 +206,7 @@
       "type": "string",
       "enum": [
         "ppc64",
-        "368",
+        "386",
         "amd64",
         "arm",
         "arm64",

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -21,6 +21,10 @@ var WebmanTmpDir string
 var RecipeDirFlag string
 var GOOS string
 var GOARCH string
+var PkgRecipeExt string = ".webman-pkg.yml"
+var GroupRecipeExt string = ".webman-group.yml"
+var RefreshFileName string = "refresh.yaml"
+var UsingFileName string = "using.yaml"
 
 func Init() {
 	homeDir, err := os.UserHomeDir()


### PR DESCRIPTION
Will resolve #18 

This is a draft of the schema, you can add it to your IDE of choice that supports it.
I will be adding some library that can ingest this schema and lint a given recipe via CLI as well.

I had minimized some of the JSON to decrease whitespace noise, but JetBrains had other ideas apparently... :sweat_smile: 

Feel free to give early feedback, particularly for descriptions or if you can think of any odd validation the code does, as I've only looked through the code briefly to look for existing validation rules.

I noticed that you only have mappings for three OS, so let me know if you also want to limit the `enum` for ARCH in the schema. Currently it's just a list I put together from `go tool dist list`, although some obvious ones like `wasm` could probably be safely ignored.