### PR TITLE
Fix windows binary name and file lock

### DIFF
--- a/cmd/add/add.go
+++ b/cmd/add/add.go
@@ -87,7 +87,15 @@ func cleanUpFailedInstall(pkg string, extractPath string) {
 	}
 }
 
-func DownloadUrl(url string, f io.Writer, pkg string, ver string, argNum int, argCount int, ml *multiline.MultiLogger) bool {
+func DownloadUrl(url string, filePath string, pkg string, ver string, argNum int, argCount int, ml *multiline.MultiLogger) bool {
+	f, err := os.OpenFile(filePath,
+		os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		ml.Printf(argNum, color.RedString("%v", err))
+		return false
+	}
+	defer f.Close()
+
 	r, err := http.Get(url)
 	ml.Printf(argNum, "Downloading file at %s", url)
 	if err != nil {

--- a/cmd/add/install_pkg.go
+++ b/cmd/add/install_pkg.go
@@ -111,17 +111,10 @@ func InstallPkg(arg string, argIndex int, argCount int, wg *sync.WaitGroup, ml *
 		ml.Printf(argIndex, color.HiBlackString("Already installed!"))
 		return true
 	}
-	f, err := os.OpenFile(downloadPath,
-		os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		ml.Printf(argIndex, color.RedString("%v", err))
-		return false
-	}
-	defer f.Close()
 	if pkgConf.IsBinary && utils.GOOS == "windows" {
 		url += ".exe"
 	}
-	if !DownloadUrl(url, f, pkg, ver, argIndex, argCount, ml) {
+	if !DownloadUrl(url, downloadPath, pkg, ver, argIndex, argCount, ml) {
 		return false
 	}
 	if pkgConf.IsBinary {
@@ -134,6 +127,9 @@ func InstallPkg(arg string, argIndex int, argCount int, wg *sync.WaitGroup, ml *
 			return false
 		}
 		binPath := filepath.Join(extractPath, pkgConf.Title)
+		if utils.GOOS == "windows" {
+			binPath += ".exe"
+		}
 		if err = os.Rename(downloadPath, binPath); err != nil {
 			ml.Printf(argIndex, color.RedString("Failed to rename temporary download to new path!"))
 			return false


### PR DESCRIPTION
Playing around on windows a bit, I ran into an issue downloading `jq`.

1. The file was being held open after downloading, which meant that renaming/moving the file was failing.
   1. I fixed this by moving the file operation into the download function entirely.
2. As well, it seems when it downloaded the binary it stripped the extension, and was then getting confused when it tried to make the batch link.
   1. I added a check for windows and re-applied the extension when renaming/moving