### PR TITLE
Add Gitea release strategy

### DIFF
--- a/pkgparse/gitea.go
+++ b/pkgparse/gitea.go
@@ -23,7 +23,7 @@ func getLatestGiteaReleaseTag(baseURL string, user string, repo string, allowPre
 	}
 	var releases []ReleaseTagInfo
 	if err = json.Unmarshal(body, &releases); err != nil {
-		return nil, fmt.Errorf("github releases JSON response not in expected format")
+		return nil, fmt.Errorf("gitea releases JSON response not in expected format")
 	}
 	if len(releases) == 0 {
 		return nil, fmt.Errorf("expected at least one release listed at %s, unable to resolve latest", url)

--- a/pkgparse/parser.go
+++ b/pkgparse/parser.go
@@ -39,6 +39,7 @@ type PkgConfig struct {
 	BaseDownloadUrl string `yaml:"base_download_url"`
 	GitUser         string `yaml:"git_user"`
 	GitRepo         string `yaml:"git_repo"`
+	GiteaURL        string `yaml:"gitea_url"`
 	SourceUrl       string `yaml:"source_url"`
 
 	FilenameFormat   string `yaml:"filename_format"`
@@ -199,6 +200,8 @@ func ParsePkgConfigLocal(pkg string, strict bool) (*PkgConfig, error) {
 	pkgConf.SourceUrl = strings.ReplaceAll(pkgConf.SourceUrl, "[GIT_USER]", pkgConf.GitUser)
 	pkgConf.SourceUrl = strings.ReplaceAll(pkgConf.SourceUrl, "[GIT_REPO]", pkgConf.GitRepo)
 
+	pkgConf.GiteaURL = strings.TrimRight(pkgConf.GiteaURL, "/")
+
 	return &pkgConf, nil
 }
 
@@ -217,6 +220,12 @@ func (pkgConf *PkgConfig) GetLatestVersion() (*string, error) {
 			return nil, err
 		}
 		version = rel.PkgVer
+	case "gitea-release":
+		rel, err := getLatestGiteaReleaseTag(pkgConf.GiteaURL, pkgConf.GitUser, pkgConf.GitRepo, pkgConf.AllowPrerelease)
+		if err != nil {
+			return nil, err
+		}
+		version = rel.TagName
 	}
 	if version == "" {
 		return nil, fmt.Errorf("no implemented latest version resolution strategy for %q",

--- a/schema/pkg_schema.json
+++ b/schema/pkg_schema.json
@@ -43,6 +43,10 @@
       "description": "Git repository",
       "type": "string"
     },
+    "gitea_url": {
+      "description": "Gitea URL",
+      "type": "string"
+    },
     "source_url": {
       "description": "Source URL",
       "type": "string"
@@ -60,7 +64,8 @@
       "type": "string",
       "enum": [
         "github-release",
-        "arch-linux-community"
+        "arch-linux-community",
+        "gitea-release"
       ]
     },
     "force_latest": {
@@ -186,6 +191,18 @@
       },
       "required": [
         "arch_linux_pkg_name"
+      ]
+    },
+    {
+      "properties": {
+        "latest_strategy": {
+          "const": "gitea-release"
+        }
+      },
+      "required": [
+        "git_user",
+        "git_repo",
+        "gitea_url"
       ]
     }
   ],


### PR DESCRIPTION
Thankfully Gitea shares much of its API responses with GitHub, so I was able to re-use the GH structs.

This adds a new `latest_strategy = gitea-release`, as well as adds `gitea_url` to the schema.

`gitea_url` trims off any ending `/` for consistency.

Resolves #23 