### PR TITLE
Look for existing binary when installing

### DIFF
--- a/cmd/add/install_pkg.go
+++ b/cmd/add/install_pkg.go
@@ -3,7 +3,9 @@ package add
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/candrewlee14/webman/link"
@@ -182,5 +184,8 @@ func InstallPkg(arg string, argIndex int, argCount int, wg *sync.WaitGroup, ml *
 		ml.Printf(argIndex, "Now using %s@%s", color.CyanString(pkg), color.MagentaString(ver))
 	}
 	ml.Printf(argIndex, color.GreenString("Successfully installed!"))
+	if p, err := exec.LookPath(pkg); err == nil && !strings.Contains(p, utils.WebmanBinDir) {
+		ml.Printf(argIndex, color.YellowString("Found another binary at %q that may interfere", p))
+	}
 	return true
 }


### PR DESCRIPTION
Sometimes I install something from webman and forget that I already `go install`ed it before, but because of how my PATH is set up the `GOBIN` version is found first. Sometimes it takes a bit before I remember and remove the conflicting binary.

This PR just shows a warning if a matching binary is found _outside_ the webman bin dir.