### PR TITLE
Add config commands

### DIFF
--- a/cmd/add_cmd.go
+++ b/cmd/add_cmd.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/candrewlee14/webman/cmd/add"
+	"github.com/candrewlee14/webman/cmd/config"
 	"github.com/candrewlee14/webman/cmd/dev"
 	"github.com/candrewlee14/webman/cmd/group"
 	"github.com/candrewlee14/webman/cmd/remove"
@@ -13,6 +14,7 @@ import (
 
 func init() {
 	rootCmd.AddCommand(add.AddCmd)
+	rootCmd.AddCommand(config.ConfigCmd)
 	rootCmd.AddCommand(dev.DevCmd)
 	rootCmd.AddCommand(remove.RemoveCmd)
 	rootCmd.AddCommand(run.RunCmd)

--- a/cmd/config/add/config_add.go
+++ b/cmd/config/add/config_add.go
@@ -1,0 +1,112 @@
+package add
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/AlecAivazis/survey/v2/core"
+	"github.com/candrewlee14/webman/config"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+var AddCmd = &cobra.Command{
+	Use:   "add",
+	Short: "add a package repository",
+	Long: `
+
+The "config add" subcommand allows you to add a package repository.
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+
+		var repo PkgRepo
+		qs := []*survey.Question{
+			{
+				Name: "name",
+				Prompt: &survey.Input{
+					Message: "Repository name",
+				},
+				Validate: survey.Required,
+			},
+			{
+				Name: "type",
+				Prompt: &survey.Select{
+					Message: "Repository type",
+					Options: []string{"gitea", "github"},
+				},
+				Validate: survey.Required,
+			},
+			{
+				Name: "user",
+				Prompt: &survey.Input{
+					Message: "Git user name",
+				},
+				Validate: survey.Required,
+			},
+			{
+				Name: "repo",
+				Prompt: &survey.Input{
+					Message: "Git repository name",
+				},
+				Validate: survey.Required,
+			},
+			{
+				Name: "branch",
+				Prompt: &survey.Input{
+					Message: "Git branch name",
+					Default: "main",
+				},
+			},
+		}
+
+		if err := survey.Ask(qs, &repo); err != nil {
+			return err
+		}
+
+		if repo.Type == config.PkgRepoTypeGitea {
+			q := &survey.Input{
+				Message: "Gitea URL",
+			}
+			if err := survey.AskOne(q, &repo.GiteaURL, survey.WithValidator(survey.Required)); err != nil {
+				return err
+			}
+		}
+
+		p := config.PkgRepo(repo)
+		cfg.PkgRepos = append(cfg.PkgRepos, &p)
+
+		if err := cfg.Save(); err != nil {
+			return err
+		}
+
+		color.HiGreen("Repository %q successfully added", repo.Name)
+		return nil
+	},
+}
+
+// PkgRepo overrides config.PkgRepo in order to implement WriteAnswer without polluting the config package
+// with survey details
+type PkgRepo config.PkgRepo
+
+func (p *PkgRepo) WriteAnswer(field string, value any) error {
+	switch field {
+	case "name":
+		p.Name = fmt.Sprint(value)
+	case "type":
+		p.Type = config.PkgRepoType(value.(core.OptionAnswer).Value)
+	case "user":
+		p.User = fmt.Sprint(value)
+	case "repo":
+		p.Repo = fmt.Sprint(value)
+	case "branch":
+		p.Branch = fmt.Sprint(value)
+	default:
+		return errors.New("unknown field")
+	}
+	return nil
+}

--- a/cmd/config/add/config_add.go
+++ b/cmd/config/add/config_add.go
@@ -78,6 +78,11 @@ The "config add" subcommand allows you to add a package repository.
 		}
 
 		p := config.PkgRepo(repo)
+
+		if err := p.RefreshRecipes(); err != nil {
+			return err
+		}
+
 		cfg.PkgRepos = append(cfg.PkgRepos, &p)
 
 		if err := cfg.Save(); err != nil {

--- a/cmd/config/add/config_add.go
+++ b/cmd/config/add/config_add.go
@@ -4,9 +4,10 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/candrewlee14/webman/config"
+
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/core"
-	"github.com/candrewlee14/webman/config"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/fatih/color"
-
-	"github.com/AlecAivazis/survey/v2"
 	"github.com/candrewlee14/webman/cmd/config/add"
 	"github.com/candrewlee14/webman/cmd/config/remove"
 	"github.com/candrewlee14/webman/config"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/fatih/color"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/candrewlee14/webman/cmd/config/add"
+	"github.com/candrewlee14/webman/cmd/config/remove"
+	"github.com/candrewlee14/webman/config"
+	"github.com/spf13/cobra"
+)
+
+var ConfigCmd = &cobra.Command{
+	Use:   "config",
+	Short: "subcommands for webman config",
+	Long: `
+
+The "config" subcommand allows you to change your base webman config.
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+
+		q := &survey.Input{
+			Message: "Refresh interval",
+			Help:    "How long before webman should refresh a package repository",
+			Default: cfg.RefreshInterval.String(),
+		}
+
+		if err := survey.AskOne(q, &cfg.RefreshInterval, survey.WithValidator(func(ans interface{}) error {
+			_, err := time.ParseDuration(fmt.Sprint(ans))
+			return err
+		})); err != nil {
+			return err
+		}
+
+		if err := cfg.Save(); err != nil {
+			return err
+		}
+
+		color.HiGreen("Config saved")
+		return nil
+	},
+}
+
+func init() {
+	ConfigCmd.AddCommand(add.AddCmd)
+	ConfigCmd.AddCommand(remove.RemoveCmd)
+}

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -28,7 +28,7 @@ The "config" subcommand allows you to change your base webman config.
 
 		q := &survey.Input{
 			Message: "Refresh interval",
-			Help:    "How long before webman should refresh a package repository",
+			Help:    "How long before webman should refresh a package repository (ex: `6h`)",
 			Default: cfg.RefreshInterval.String(),
 		}
 

--- a/cmd/config/remove/config_remove.go
+++ b/cmd/config/remove/config_remove.go
@@ -1,0 +1,52 @@
+package remove
+
+import (
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/candrewlee14/webman/config"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+var RemoveCmd = &cobra.Command{
+	Use:     "remove",
+	Aliases: []string{"delete"},
+	Short:   "remove a package repository",
+	Long: `
+
+The "config remove" subcommand allows you to remove a package repository.
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+
+		opts := make([]string, 0, len(cfg.PkgRepos))
+		for _, pkgRepo := range cfg.PkgRepos {
+			opts = append(opts, pkgRepo.Name)
+		}
+
+		q := &survey.Select{
+			Message: "Repository to remove",
+			Options: opts,
+		}
+
+		var pkg string
+		if err := survey.AskOne(q, &pkg, survey.WithValidator(survey.Required)); err != nil {
+			return err
+		}
+
+		for idx, pkgRepo := range cfg.PkgRepos {
+			if pkgRepo.Name == pkg {
+				cfg.PkgRepos = append(cfg.PkgRepos[:idx], cfg.PkgRepos[idx+1:]...)
+				break
+			}
+		}
+		if err := cfg.Save(); err != nil {
+			return err
+		}
+
+		color.HiGreen("Repository %q successfully removed", pkg)
+		return nil
+	},
+}

--- a/cmd/config/remove/config_remove.go
+++ b/cmd/config/remove/config_remove.go
@@ -1,6 +1,9 @@
 package remove
 
 import (
+	"errors"
+	"os"
+
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/candrewlee14/webman/config"
 	"github.com/fatih/color"
@@ -21,6 +24,10 @@ The "config remove" subcommand allows you to remove a package repository.
 			return err
 		}
 
+		if len(cfg.PkgRepos) == 1 {
+			return errors.New("cannot remove only package repository")
+		}
+
 		opts := make([]string, 0, len(cfg.PkgRepos))
 		for _, pkgRepo := range cfg.PkgRepos {
 			opts = append(opts, pkgRepo.Name)
@@ -36,12 +43,21 @@ The "config remove" subcommand allows you to remove a package repository.
 			return err
 		}
 
+		var remove *config.PkgRepo
 		for idx, pkgRepo := range cfg.PkgRepos {
 			if pkgRepo.Name == pkg {
+				remove = pkgRepo
 				cfg.PkgRepos = append(cfg.PkgRepos[:idx], cfg.PkgRepos[idx+1:]...)
 				break
 			}
 		}
+
+		if remove != nil {
+			if err := os.RemoveAll(remove.Path()); err != nil {
+				return err
+			}
+		}
+
 		if err := cfg.Save(); err != nil {
 			return err
 		}

--- a/cmd/config/remove/config_remove.go
+++ b/cmd/config/remove/config_remove.go
@@ -4,8 +4,9 @@ import (
 	"errors"
 	"os"
 
-	"github.com/AlecAivazis/survey/v2"
 	"github.com/candrewlee14/webman/config"
+
+	"github.com/AlecAivazis/survey/v2"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )

--- a/config/config.go
+++ b/config/config.go
@@ -96,6 +96,7 @@ func (p PkgRepo) RefreshRecipes() error {
 	if err != nil {
 		return err
 	}
+	defer os.RemoveAll(tmpZipFile.Name())
 	if _, err = io.Copy(tmpZipFile, r.Body); err != nil {
 		return err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -21,11 +21,13 @@ import (
 //go:embed config.yaml
 var defaultConfig []byte
 
+// Config is a Webman config
 type Config struct {
 	RefreshInterval time.Duration `yaml:"refresh_interval"`
 	PkgRepos        []*PkgRepo    `yaml:"pkg_repos"`
 }
 
+// PkgRepoType is the package repository type
 type PkgRepoType string
 
 const (
@@ -33,6 +35,7 @@ const (
 	PkgRepoTypeGitea  PkgRepoType = "gitea"
 )
 
+// PkgRepo is a package repository
 type PkgRepo struct {
 	Name   string      `yaml:"name"`
 	Type   PkgRepoType `yaml:"type"`
@@ -43,10 +46,12 @@ type PkgRepo struct {
 	GiteaURL string `yaml:"gitea_url"`
 }
 
+// Path is the filepath to a given PkgRepo
 func (p PkgRepo) Path() string {
 	return filepath.Join(utils.WebmanRecipeDir, p.Name)
 }
 
+// ShouldRefreshRecipes determines whether a PkgRepo needs to be refreshed
 func (p PkgRepo) ShouldRefreshRecipes(refreshInterval time.Duration) (bool, error) {
 	fi, err := os.Stat(p.Path())
 	if err != nil {
@@ -59,6 +64,7 @@ func (p PkgRepo) ShouldRefreshRecipes(refreshInterval time.Duration) (bool, erro
 	return time.Since(fi.ModTime()) > refreshInterval, nil
 }
 
+// RefreshRecipes refreshes the recipes for a PkgRepo
 func (p PkgRepo) RefreshRecipes() error {
 	var url string
 	switch p.Type {
@@ -113,6 +119,17 @@ func (p PkgRepo) RefreshRecipes() error {
 	return nil
 }
 
+// Save saves the Config
+func (c *Config) Save() error {
+	fi, err := os.Create(utils.WebmanConfig)
+	if err != nil {
+		return err
+	}
+	defer fi.Close()
+	return yaml.NewEncoder(fi).Encode(c)
+}
+
+// Load loads the Webman Config
 func Load() (*Config, error) {
 	if utils.RecipeDirFlag != "" {
 		// local only


### PR DESCRIPTION
Closes #37 

`webman config` - Base command allows changing top-level config, currently only the refresh interval
`webman config remove` - Remove a package repository
`webman config add` - Add a package repository

Part of me wants to be conservative and change add/remove to something like `repo-add` or another subcommand `repo add`
But that would get a bit verbose, and I'm not sure it's worth the conservation currently.