### PR TITLE
Validate package repo structure

### DIFF
--- a/cmd/config/add/config_add.go
+++ b/cmd/config/add/config_add.go
@@ -80,6 +80,14 @@ The "config add" subcommand allows you to add a package repository.
 
 		p := config.PkgRepo(repo)
 
+		ok, err := p.Validate()
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("%q is an invalid package repository; no `pkgs` sub-directory", p.Name)
+		}
+
 		if err := p.RefreshRecipes(); err != nil {
 			return err
 		}


### PR DESCRIPTION
This is a basic check for package repo structure.
Currently it checks if there is a `pkgs` sub-directory in the repo.

It is also fairly naive, i.e. it reports any `404` as invalid rather than inspect the various reasons for `404`, like username/repo not existing at all.

-----

Is anything else required for a "valid" structure? I know there is also a `groups` sub-dir, but afaict that's not "required".