### PR TITLE
Denote installed packages when searching

### DIFF
--- a/cmd/search/search.go
+++ b/cmd/search/search.go
@@ -73,10 +73,19 @@ The "search" subcommand starts an interactive window to find and display info ab
 			return pkgInfos[i].Title < pkgInfos[j].Title
 		})
 
+		installed := utils.InstalledPackages()
+		installedSet := make(map[string]struct{})
+		for _, i := range installed {
+			installedSet[i] = struct{}{}
+		}
 		idx, err := fuzzyfinder.Find(
 			pkgInfos,
 			func(i int) string {
-				return pkgInfos[i].Title + " - " + pkgInfos[i].Tagline
+				pre := "   "
+				if _, ok := installedSet[pkgInfos[i].Title]; ok {
+					pre = "✅  "
+				}
+				return pre + pkgInfos[i].Title + " - " + pkgInfos[i].Tagline
 			},
 			fuzzyfinder.WithPreviewWindow(func(i, w, h int) string {
 				if i == -1 {

--- a/cmd/search/search.go
+++ b/cmd/search/search.go
@@ -83,7 +83,7 @@ The "search" subcommand starts an interactive window to find and display info ab
 			func(i int) string {
 				pre := "   "
 				if _, ok := installedSet[pkgInfos[i].Title]; ok {
-					pre = "✅  "
+					pre = "✅ "
 				}
 				return pre + pkgInfos[i].Title + " - " + pkgInfos[i].Tagline
 			},

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -89,3 +89,16 @@ func ParseStem(pkgVerStem string) (string, string) {
 	pkg, ver, _ := strings.Cut(pkgVerStem, "-")
 	return pkg, ver
 }
+
+// InstalledPackages returns a list of currently installed packages, as per the webman pkgs directory
+func InstalledPackages() []string {
+	var pkgs []string
+	entries, err := os.ReadDir(WebmanPkgDir)
+	if err != nil {
+		return nil
+	}
+	for _, entry := range entries {
+		pkgs = append(pkgs, entry.Name())
+	}
+	return pkgs
+}


### PR DESCRIPTION
Small UX thing, it would be nice to visually see which packages are installed, especially as I peruse new packages from time to time. 🙂 

![webman-list](https://user-images.githubusercontent.com/42128690/192902265-098a219c-327a-4dc4-813b-7897bc6953ab.png)
