### PR TITLE
Add gitinfo for non-release builds

### DIFF
--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -1,6 +1,8 @@
 package version
 
 import (
+	"runtime/debug"
+
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
@@ -8,6 +10,7 @@ import (
 var (
 	Version = "dev"
 	Commit  = "none"
+	dirty   bool
 	Date    = "unknown"
 	BuiltBy = "unknown"
 )
@@ -27,7 +30,11 @@ The "version" subcommand displays the latest webman version.`,
 		if len(Commit) < 8 {
 			verLen = len(Commit)
 		}
-		color.Yellow("Commit %s", Commit[:verLen])
+		Commit = Commit[:verLen]
+		if dirty {
+			Commit += " (with changes)"
+		}
+		color.Yellow("Commit %s", Commit)
 		dateLen := 10
 		if len(Date) < 10 {
 			dateLen = len(Date)
@@ -36,4 +43,23 @@ The "version" subcommand displays the latest webman version.`,
 		color.HiBlack("Created by candrewlee14")
 		return nil
 	},
+}
+
+func init() {
+	if Version != "dev" {
+		return
+	}
+	info, ok := debug.ReadBuildInfo()
+	if ok {
+		for _, setting := range info.Settings {
+			switch setting.Key {
+			case "vcs.revision":
+				Commit = setting.Value
+			case "vcs.time":
+				Date = setting.Value
+			case "vcs.modified":
+				dirty = setting.Value == "true"
+			}
+		}
+	}
 }

--- a/pkgparse/parser.go
+++ b/pkgparse/parser.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	
+
 	"github.com/candrewlee14/webman/config"
 	"github.com/candrewlee14/webman/utils"
 


### PR DESCRIPTION
This is a small UX thing that might be useful for devs especially to keep track of local builds.

Go embeds a portion of git data into builds that we can use when someone installs via `go install`.

It will only be set if `Version != "dev"`, which means releases shouldn't be affected.
"dirty" in the build info refers to whether changes were made that aren't part of a commit.

Clean
![gitinfo-clean](https://user-images.githubusercontent.com/42128690/193295229-638148b1-fead-49c5-a160-a1913a8beba7.png)
Note: "clean" does not mean release, it just means a commit with no working changes.
https://github.com/candrewlee14/webman/commit/dc9866ca

Dirty
![gitinfo-dirty](https://user-images.githubusercontent.com/42128690/193295236-7dc8ee95-9a4a-419a-adda-d7c4bc248ff4.png)
