### PR TITLE
New latest strategy

### DIFF
--- a/pkgparse/parser.go
+++ b/pkgparse/parser.go
@@ -61,6 +61,7 @@ type PkgConfig struct {
 	FilenameFormat   string `yaml:"filename_format"`
 	VersionFormat    string `yaml:"version_format"`
 	LatestStrategy   string `yaml:"latest_strategy"`
+	LatestVersion    string `yaml:"latest_version"`
 	ForceLatest      bool   `yaml:"force_latest"`
 	AllowPrerelease  bool   `yaml:"allow_prerelease"`
 	ArchLinuxPkgName string `yaml:"arch_linux_pkg_name"`
@@ -277,6 +278,8 @@ func (pkgConf *PkgConfig) GetLatestVersion() (*string, error) {
 			return nil, err
 		}
 		version = rel.TagName
+	case "fixed":
+		version = pkgConf.LatestVersion
 	}
 	if version == "" {
 		return nil, fmt.Errorf("no implemented latest version resolution strategy for %q",

--- a/schema/pkg_schema.json
+++ b/schema/pkg_schema.json
@@ -73,8 +73,13 @@
       "enum": [
         "github-release",
         "arch-linux-community",
-        "gitea-release"
+        "gitea-release",
+        "fixed"
       ]
+    },
+    "latest_version": {
+      "description": "Fixed latest version",
+      "type": "string"
     },
     "force_latest": {
       "description": "Force latest release",

--- a/testcases/pkgs/maven.webman-pkg.yml
+++ b/testcases/pkgs/maven.webman-pkg.yml
@@ -2,12 +2,6 @@ tagline: maven tagline
 about: |
   maven about
 
-git_user: apache
-git_repo: maven
-info_url: info_url
-releases_url: releases_url
-source_url: source_url
-
 base_download_url: https://archive.apache.org/dist/maven/maven-3/[VER]/binaries/
 version_format: '[VER]'
 filename_format: apache-maven-[VER]-bin.[EXT]

--- a/testcases/pkgs/maven.webman-pkg.yml
+++ b/testcases/pkgs/maven.webman-pkg.yml
@@ -1,0 +1,40 @@
+tagline: maven tagline
+about: |
+  maven about
+
+git_user: apache
+git_repo: maven
+info_url: info_url
+releases_url: releases_url
+source_url: source_url
+
+base_download_url: https://archive.apache.org/dist/maven/maven-3/[VER]/binaries/
+version_format: '[VER]'
+filename_format: apache-maven-[VER]-bin.[EXT]
+latest_strategy: fixed
+latest_version: '3.8.6' 
+
+os_map:
+  linux:
+    name: linux
+    ext: zip
+    bin_path: bin
+    extract_has_root: true
+  macos:
+    name: darwin
+    ext: zip
+    bin_path: bin
+    extract_has_root: true
+  win:
+    name: windows
+    ext: zip
+    bin_path: bin
+    extract_has_root: true
+
+arch_map:
+  amd64: x64
+  arm64: aarch64
+
+ignore:
+  - os: linux
+    arch: arm64


### PR DESCRIPTION
Hi,
i would like to use webman to install non-github/gitea software, eg Maven.
To do this I created a new latest strategy (`fixed`, maybe you can find a better name).
An example of a working recipe definition is in `testcases/pkgs/maven.webman-pkg.yml`.

`go run main.go -l testcases add maven`

Cheers, Enrico