### PR TITLE
Back to create windows cmd script if symlink creation fails

### DIFF
--- a/cmd/doctor/check/windows_symlink.go
+++ b/cmd/doctor/check/windows_symlink.go
@@ -61,6 +61,10 @@ var WindowsSymlink = Check{
 				}
 			}
 
+			// ---
+			// here check if no `.cmd` script
+			// ---
+
 			if !fix {
 				color.HiRed("no symlink(s) found for %q", i.Name())
 				continue

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -149,6 +149,8 @@ func runPackage(args []string) error {
 			if utils.GOOS == "windows" {
 				binExt = ".exe"
 			}
+			// WARNING: it assume the executable has .exe extension (not always true)
+			// would be better use utils.WebmanBinDir + utils.LinkName(binName) ?
 			pkgBinDirOrFile = filepath.Join(pkgBinDirOrFile, binName+binExt)
 			if _, err = os.Stat(pkgBinDirOrFile); err != nil {
 				if !os.IsNotExist(err) {

--- a/link/link.go
+++ b/link/link.go
@@ -99,10 +99,7 @@ func AddLink(old string, new string) (bool, error) {
 			return false, err
 		}
 	}
-	if err := os.Symlink(old, new); err != nil {
-		return false, err
-	}
-	return true, nil
+	return symlink(old, new)
 }
 
 func CreateLinks(pkg string, ver string, confBinPaths []string, renames []pkgparse.RenameItem) (bool, error) {

--- a/link/link.go
+++ b/link/link.go
@@ -34,7 +34,7 @@ func GetBinPathsAndLinkPaths(
 			linkPath := GetLinkPathIfExec(binPath, renames)
 			if linkPath != nil {
 				binPaths = append(binPaths, binPath)
-				linkPaths = append(linkPaths, *linkPath+binExt)
+				linkPaths = append(linkPaths, utils.LinkName(*linkPath))
 			}
 		} else {
 			binDir := filepath.Join(utils.WebmanPkgDir, pkg, stem, confBinPath)
@@ -48,7 +48,7 @@ func GetBinPathsAndLinkPaths(
 					linkPath := GetLinkPathIfExec(binPath, renames)
 					if linkPath != nil {
 						binPaths = append(binPaths, binPath)
-						linkPaths = append(linkPaths, *linkPath+binExt)
+						linkPaths = append(linkPaths, utils.LinkName(*linkPath))
 					}
 				}
 			}

--- a/link/link_unix.go
+++ b/link/link_unix.go
@@ -1,0 +1,15 @@
+//go:build darwin || freebsd || linux || netbsd || openbsd
+// +build darwin freebsd linux netbsd openbsd
+
+package link
+
+import "os"
+
+func symlink(old string, new string) (bool, error) {
+	err := os.Symlink(old, new)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/link/link_windows.go
+++ b/link/link_windows.go
@@ -3,6 +3,11 @@
 
 package link
 
+import (
+	"fmt"
+	"os"
+)
+
 // If symlink creation fails, fallbacks to `.bat` script.
 func symlink(old string, new string) (bool, error) {
 	err := os.Symlink(old, new)
@@ -21,5 +26,5 @@ func symlink(old string, new string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-
+	return true, nil
 }

--- a/link/link_windows.go
+++ b/link/link_windows.go
@@ -6,25 +6,32 @@ package link
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
-// If symlink creation fails, fallbacks to `.bat` script.
+// If symlink creation fails, fallbacks to creating a script named `${executable name minus extension}.cmd`.
 func symlink(old string, new string) (bool, error) {
 	err := os.Symlink(old, new)
 	if err == nil {
 		return true, nil
 	}
 
-	f, err := os.Create(new + ".bat")
+	f, err := os.Create(cmdPath(new))
 	if err != nil {
 		return false, err
 	}
 	defer f.Close()
 	_, err = f.WriteString(
-		fmt.Sprintf("@echo off\n%s", old) + ` %*`,
+		fmt.Sprintf("@echo off\r\n%s %s\r\n", old, `%*`),
 	)
 	if err != nil {
 		return false, err
 	}
 	return true, nil
+}
+
+func cmdPath(orig string) string {
+	fmt.Printf("   orig %s \n", orig)
+	noext := orig[:len(orig)-len(filepath.Ext(orig))]
+	return fmt.Sprintf(`%s.cmd`, noext)
 }

--- a/link/link_windows.go
+++ b/link/link_windows.go
@@ -31,7 +31,6 @@ func symlink(old string, new string) (bool, error) {
 }
 
 func cmdPath(orig string) string {
-	fmt.Printf("   orig %s \n", orig)
 	noext := orig[:len(orig)-len(filepath.Ext(orig))]
 	return fmt.Sprintf(`%s.cmd`, noext)
 }

--- a/link/link_windows.go
+++ b/link/link_windows.go
@@ -1,0 +1,25 @@
+//go:build windows
+// +build windows
+
+package link
+
+// If symlink creation fails, fallbacks to `.bat` script.
+func symlink(old string, new string) (bool, error) {
+	err := os.Symlink(old, new)
+	if err == nil {
+		return true, nil
+	}
+
+	f, err := os.Create(new + ".bat")
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+	_, err = f.WriteString(
+		fmt.Sprintf("@echo off\n%s", old) + ` %*`,
+	)
+	if err != nil {
+		return false, err
+	}
+
+}

--- a/link/link_windows.go
+++ b/link/link_windows.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/candrewlee14/webman/utils"
 )
 
 // If symlink creation fails, fallbacks to creating a script named `${executable name minus extension}.cmd`.
@@ -32,5 +34,5 @@ func symlink(old string, new string) (bool, error) {
 
 func cmdPath(orig string) string {
 	noext := orig[:len(orig)-len(filepath.Ext(orig))]
-	return fmt.Sprintf(`%s.cmd`, noext)
+	return utils.LinkName(noext)
 }

--- a/utils/utils_unix.go
+++ b/utils/utils_unix.go
@@ -1,0 +1,8 @@
+//go:build darwin || freebsd || linux || netbsd || openbsd
+// +build darwin freebsd linux netbsd openbsd
+
+package utils
+
+func LinkName(pkg string) string {
+	return pkg
+}

--- a/utils/utils_windows.go
+++ b/utils/utils_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+// +build windows
+
+package utils
+
+import "fmt"
+
+func LinkName(pkg string) string {
+	return fmt.Sprintf("%s.cmd", pkg)
+}


### PR DESCRIPTION
This change allows you to use webman even if developer mode has not been enabled in windows: 
 
if symlink creation fails, fallbacks to creating a script named `${executable name minus extension}.cmd`. 
 
Could impact #53 (and maybe #11) so, if you were interested in this, it would be necessary to correct the "Windows Symlink check" which I have left untouched right now.